### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "rsbuild-plugin-html-minifier-terser",
   "version": "1.1.5",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-html-minifier-terser",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-html-minifier-terser#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-html-minifier-terser/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add package homepage metadata pointing to the repository README
- add bugs.url metadata pointing to the GitHub issue tracker

## Why
This makes the npm package page expose the project homepage and issue tracker directly.

## Validation
- node metadata assertion for homepage and bugs.url
- npm view rsbuild-plugin-html-minifier-terser@latest name version repository.url homepage bugs --json
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm run lint
- pnpm run build
- pnpm run test
- npm pack --dry-run --ignore-scripts --json .
- git diff --check