### PR TITLE
chore: reuse shared test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@rsbuild/core": "2.1.2",
     "@rslib/core": "^0.23.1",
     "@rslint/core": "^0.6.4",
+    "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.11.1",
     "@rstest/playwright": "^0.11.1",
     "@types/node": "^24.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@rslint/core':
         specifier: ^0.6.4
         version: 0.6.4
+      '@rstackjs/test-utils':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@rstest/core':
         specifier: ^0.11.1
         version: 0.11.1
@@ -396,6 +399,9 @@ packages:
         optional: true
       '@swc/helpers':
         optional: true
+
+  '@rstackjs/test-utils@0.2.0':
+    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
   '@rstest/core@0.11.1':
     resolution: {integrity: sha512-9iJnDrM/zYuHyk1//CMr/Jer2XughgN3fYagGb1YWpMLUke+E+WXlUPgACwf7OkmIB47/TttbLFK+4zwGDNOFg==}
@@ -953,6 +959,8 @@ snapshots:
       '@rspack/binding': 2.1.3
     optionalDependencies:
       '@swc/helpers': 0.5.23
+
+  '@rstackjs/test-utils@0.2.0': {}
 
   '@rstest/core@0.11.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
+  - '@rstackjs/test-utils@0.2.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,4 +9,4 @@ minimumReleaseAgeExclude:
   - typescript
   - '@typescript/*'
   - '@rstest/*'
-  - '@rstackjs/test-utils@0.2.0'
+  - '@rstackjs/*'

--- a/test/basic/index.test.ts
+++ b/test/basic/index.test.ts
@@ -20,7 +20,7 @@ test('should minify template as expected', async ({ page }) => {
       },
       plugins: [pluginHtmlMinifierTerser()],
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
     },
   });

--- a/test/basic/index.test.ts
+++ b/test/basic/index.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { expect, test } from '@rstest/playwright';
 import { createRsbuild } from '@rsbuild/core';
 import { pluginHtmlMinifierTerser } from '../../src';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/test/config/index.test.ts
+++ b/test/config/index.test.ts
@@ -25,7 +25,7 @@ test('should not minify template when minifyJS is false', async ({ page }) => {
         }),
       ],
       server: {
-        port: getRandomPort(),
+        port: await getRandomPort(),
       },
     },
   });

--- a/test/config/index.test.ts
+++ b/test/config/index.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { expect, test } from '@rstest/playwright';
 import { createRsbuild } from '@rsbuild/core';
 import { pluginHtmlMinifierTerser } from '../../src';
-import { getRandomPort } from '../helper';
+import { getRandomPort } from '@rstackjs/test-utils';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,1 +1,0 @@
-export { getRandomPort } from '@rstackjs/test-utils';

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,14 +1,1 @@
-const portMap = new Map();
-
-export function getRandomPort(
-  defaultPort = Math.ceil(Math.random() * 30000) + 15000,
-) {
-  let port = defaultPort;
-  while (true) {
-    if (!portMap.get(port)) {
-      portMap.set(port, 1);
-      return port;
-    }
-    port++;
-  }
-}
+export { getRandomPort } from '@rstackjs/test-utils';


### PR DESCRIPTION
This PR replaces the local random-port helper with `@rstackjs/test-utils` so test servers verify port availability through the shared ecosystem implementation. Call sites now await the asynchronous helper.