### PR TITLE
chore(ci): only install Chromium

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           run_install: true
 
       - name: Install Playwright
-        run: npx playwright install
+        run: npx playwright install chromium
 
       - name: Run Test
         run: pnpm run test


### PR DESCRIPTION
This PR limits the Playwright browser installation in CI to Chromium, which is the only browser exercised by the test suite. This avoids downloading unused Firefox and WebKit binaries.